### PR TITLE
fixed: StartHidden setting was overwritten on show/hide

### DIFF
--- a/src/LibCecTray/ui/CECTray.cs
+++ b/src/LibCecTray/ui/CECTray.cs
@@ -74,10 +74,10 @@ namespace LibCECTray.ui
 
     protected override void SetVisibleCore(bool value)
     {
-      if (Controller.Settings.StartHidden.Value)
+      if (Controller.Settings.StartHidden.Value && !this.IsHandleCreated)
       {
         value = false;
-        if (!this.IsHandleCreated) CreateHandle();
+        CreateHandle();
       }
       base.SetVisibleCore(value);
     }
@@ -511,12 +511,10 @@ namespace LibCECTray.ui
     {
       if (Visible && WindowState != FormWindowState.Minimized)
       {
-        Controller.Settings.StartHidden.Value = true;
         Hide();
       }
       else
       {
-        Controller.Settings.StartHidden.Value = false;
         Show();
       }
     }


### PR DESCRIPTION
Addresses Issue #5.

Previously the StartHidden setting was used to override the behaviour in SetVisibleCore, both on start and when showing/hiding the UI from the system tray. This diff only overrides the behaviour of SetVisibleCore when the Form is first starting, and does not change this user setting when hiding or showing the UI from the system tray.