### PR TITLE
fixed: attempt to write null to registry after clearing ApplicationInput

### DIFF
--- a/src/LibCecTray/controller/applications/ApplicationInput.cs
+++ b/src/LibCecTray/controller/applications/ApplicationInput.cs
@@ -436,6 +436,12 @@ namespace LibCECTray.controller.applications
       return this;
     }
 
+    public ApplicationInput Clear()
+    {
+      _input.Clear();
+      return this;
+    }
+
     private readonly List<ApplicationAction> _input = new List<ApplicationAction>();
   }
 }

--- a/src/LibCecTray/controller/applications/CecButtonConfigUI.cs
+++ b/src/LibCecTray/controller/applications/CecButtonConfigUI.cs
@@ -112,7 +112,7 @@ namespace LibCECTray.controller.applications
 
     private void BClearClick(object sender, EventArgs e)
     {
-      _button.Value = null;
+      _button.Value = _button.Value.Clear();
     }
 
     private void BAddKeyClick(object sender, EventArgs e)


### PR DESCRIPTION
Fixes #7.

Previously button mappings (ApplicationInput) were cleared by setting them to null, however when saving configuration this could easily result in an attempt to write null to the registry which would raise an exception. This diff clears ApplicationInput by clearing the inner _input list, enabling CECSettings to correctly write an empty string instead. This is correctly interpreted when read from the registry and avoids the crash.