### PR TITLE
added: ApplicationAction to suspend PC

### DIFF
--- a/src/LibCecTray/Properties/Resources.Designer.cs
+++ b/src/LibCecTray/Properties/Resources.Designer.cs
@@ -286,6 +286,15 @@ namespace LibCECTray.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to suspend PC.
+        /// </summary>
+        internal static string action_type_suspend_pc {
+            get {
+                return ResourceManager.GetString("action_type_suspend_pc", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Add new application.
         /// </summary>
         internal static string add_new_application {

--- a/src/LibCecTray/Properties/Resources.resx
+++ b/src/LibCecTray/Properties/Resources.resx
@@ -626,4 +626,7 @@ CEC will not work (properly) if the TV does not support CEC, or has CEC disabled
   <data name="application_foreground" xml:space="preserve">
     <value>Foreground application</value>
   </data>
+  <data name="action_type_suspend_pc" xml:space="preserve">
+    <value>suspend PC</value>
+  </data>
 </root>

--- a/src/LibCecTray/controller/applications/ApplicationInput.cs
+++ b/src/LibCecTray/controller/applications/ApplicationInput.cs
@@ -47,7 +47,8 @@ namespace LibCECTray.controller.applications
     Generic = 0,
     CloseControllerApplication = 1,
     StartApplication = 2,
-    SendKey = 3
+    SendKey = 3,
+    SuspendPc = 4
   }
 
   /// <summary>
@@ -297,6 +298,8 @@ namespace LibCECTray.controller.applications
           return Resources.action_type_start_application;
         case ActionType.SendKey:
           return Resources.action_type_sendkey;
+        case ActionType.SuspendPc:
+          return Resources.action_type_suspend_pc;
         default:
           return type.ToString();
       }
@@ -408,6 +411,9 @@ namespace LibCECTray.controller.applications
         if (addAction == null || addAction.Empty())
           addAction = ApplicationActionStart.FromString(controller, item);
 
+        if (addAction == null || addAction.Empty())
+          addAction = ApplicationActionSuspendPc.FromString(controller, item);
+
         if (addAction != null && !addAction.Empty())
           retVal.Append(addAction);
       }
@@ -432,10 +438,75 @@ namespace LibCECTray.controller.applications
         case ActionType.StartApplication:
           Append(new ApplicationActionStart(Controller));
           break;
+        case ActionType.SuspendPc:
+          Append(new ApplicationActionSuspendPc(Controller));
+          break;
       }
       return this;
     }
 
     private readonly List<ApplicationAction> _input = new List<ApplicationAction>();
+  }
+  
+  /// <summary>
+  /// Suspends the host PC
+  /// </summary>
+  internal class ApplicationActionSuspendPc : ApplicationAction
+  {
+    public ApplicationActionSuspendPc(ApplicationController controller) :
+      base(controller, ActionType.SuspendPc)
+    {
+    }
+
+    public override bool Transmit(IntPtr windowHandle)
+    {
+      return Application.SetSuspendState(PowerState.Suspend, true, false);
+    }
+
+    public override string AsString()
+    {
+      return TypePrefix;
+    }
+
+    public override string AsFriendlyString()
+    {
+      return string.Format("[{0}]", Resources.action_type_suspend_pc);
+    }
+
+    public override bool Empty()
+    {
+      return false;
+    }
+
+    public override bool CanAppend(ApplicationAction value)
+    {
+      return false;
+    }
+
+    public override ApplicationAction Append(ApplicationAction value)
+    {
+      return this;
+    }
+
+    public override ApplicationAction RemoveKey(int index)
+    {
+      return null;
+    }
+
+    public static ApplicationAction FromString(ApplicationController controller, string value)
+    {
+      ApplicationActionSuspendPc retVal = new ApplicationActionSuspendPc(controller);
+      return value.Trim().Equals(retVal.AsString()) ? retVal : null;
+    }
+
+    public static bool HasDefaultValue(CecKeypress key)
+    {
+      return DefaultValue(key) != null;
+    }
+
+    public static ApplicationAction DefaultValue(CecKeypress key)
+    {
+      return null;
+    }
   }
 }

--- a/src/LibCecTray/controller/applications/CecButtonConfigUI.cs
+++ b/src/LibCecTray/controller/applications/CecButtonConfigUI.cs
@@ -65,6 +65,7 @@ namespace LibCECTray.controller.applications
       //TODO
       cbAddAction.Items.Add(ApplicationInput.FriendlyActionName(ActionType.CloseControllerApplication));
       cbAddAction.Items.Add(ApplicationInput.FriendlyActionName(ActionType.StartApplication));
+      cbAddAction.Items.Add(ApplicationInput.FriendlyActionName(ActionType.SuspendPc));
 
       // take the icon of the main window
       ComponentResourceManager resources = new ComponentResourceManager(typeof(CECTray));


### PR DESCRIPTION
Fixes #9.

Although the "sleep" button mapping does not work correctly in newer versions of Windows, reliable APIs are available for doing so. This diff adds a new action (alongside "close CECTray" and "start application") which enables the user to configure libCECTray to suspend their PC via a button mapping. This follows the same mechanism as other ApplicationActions but calls [`Application.SetSuspendState`](https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.application.setsuspendstate) when triggered. The parameters used trigger a suspend (i.e. sleep as opposed to hibernate), forcing the suspend to occur immediately, and ensuring wake events are not disabled when doing so.