### PR TITLE
Fix null-reference exception when running cec-tray

### DIFF
--- a/src/LibCecTray/settings/CECSetting.cs
+++ b/src/LibCecTray/settings/CECSetting.cs
@@ -139,7 +139,6 @@ namespace LibCECTray.settings
           _value = key.GetValue(KeyName) ?? DefaultValue;
           Changed = false;
         }
-        key.Close();
       }
     }
 


### PR DESCRIPTION
Remove disposing of registry key inside of `using` statement. `RegistryKey` implements `IDisposible`, so `using` will call close automatically when `key` goes out of scope. 

This fix is in relation to https://github.com/Pulse-Eight/libcec/issues/522 .

Note: I'm not sure if this is related to this change, but when running cec-tray from Visual Studio, it appears as though the firmware update for my device is not working. In the screenshot below, my firmware is only at v8, yet on the support page http://support.pulse-eight.com/support/solutions/articles/30000041207 it seems the latest firmware for this device is at v12. Additionally, there is no disabled update button.

![image](https://user-images.githubusercontent.com/1094516/87193085-d41f1300-c2ef-11ea-94c2-5f1958979407.png)
